### PR TITLE
Fix nightlies and adds some docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,14 @@ Delete the local tag, re-create it, and force push it up:
 
 > `git tag -d 3.8.2 && git tag 3.8.2 && git push origin 3.8.2 -f`
 
-Note that npm won't allow re-publishing the same version, so you better do it quick if you need to edit it.
+Note that npm won't allow re-publishing the same version, so you better do it quick if you need to edit it. The playground doesn't use the npm versions however, so they will get updated.
+
+### Troubleshooting
+
+Are you here because of a failing build? Chances are your issue comes up from a `require` statement inside the TypeScript codebase. 
+The logs will let you know if this is the issue.
+
+This has happened a few times, you need to go to [microsoft/monaco-typescript](https://github.com/microsoft/monaco-typescript) and look at [`./scripts/importTypeScript.js`](https://github.com/microsoft/monaco-typescript/blob/master/scripts/importTypescript.js). Fix it there (I update the TS version in that repo, then fix the script, and send a PR for just that script change: e.g. [#72](https://github.com/microsoft/monaco-typescript/pull/72)) then come back to the file in this repo: [`./publish-monaco-ts.js`](https://github.com/orta/make-monaco-builds/blob/master/publish-monaco-ts.js) and add a step to merge in your new PR.
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Note that npm won't allow re-publishing the same version, so you better do it qu
 Are you here because of a failing build? Chances are your issue comes up from a `require` statement inside the TypeScript codebase. 
 The logs will let you know if this is the issue.
 
-This has happened a few times, you need to go to [microsoft/monaco-typescript](https://github.com/microsoft/monaco-typescript) and look at [`./scripts/importTypeScript.js`](https://github.com/microsoft/monaco-typescript/blob/master/scripts/importTypescript.js). Fix it there (I update the TS version in that repo, then fix the script, and send a PR for just that script change: e.g. [#72](https://github.com/microsoft/monaco-typescript/pull/72)) then come back to the file in this repo: [`./publish-monaco-ts.js`](https://github.com/orta/make-monaco-builds/blob/master/publish-monaco-ts.js) and add a step to merge in your new PR.
+This has happened a few times, you need to go to [microsoft/monaco-typescript](https://github.com/microsoft/monaco-typescript) and look at [`./scripts/importTypeScript.js`](https://github.com/microsoft/monaco-typescript/blob/master/scripts/importTypescript.js). Fix it there (I update the TS version in that repo, then fix the script, and send a PR for just that script change: e.g. [#72](https://github.com/microsoft/monaco-typescript/pull/72)) then come back to the file in this repo: [`./publish-monaco-ts.js`](https://github.com/orta/make-monaco-builds/blob/master/publish-monaco-ts.js) and add a step to merge in your new PR e.g. [#3](https://github.com/microsoft/TypeScript-Make-Monaco-Builds/pull/3).
 
 # Contributing
 

--- a/publish-monaco-ts.js
+++ b/publish-monaco-ts.js
@@ -43,7 +43,7 @@ function main() {
   execMTS(`git config --global user.email "you@example.com"`)
   execMTS(`git config --global user.name "Your Name"`)
 
-  failableMergeBranch(execMTS, "ts_4_1_b")
+  failableMergeBranch(execMTS, "41_perf_require")
 
   step("Installing NPM");
   execMTS("npm i")


### PR DESCRIPTION
Using `failableMergeBranch` so that if/when it is merged into master then the builds won't be halted.