### PR TITLE
Update Node version

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: "12.x"
+          node-version: "16.x"
           registry-url: "https://registry.npmjs.org"
 
       # Lets us use one-liner JSON manipulations on package.jsons

--- a/.github/workflows/nightly_check_prod_deploys.yml
+++ b/.github/workflows/nightly_check_prod_deploys.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: "12.x"
+          node-version: "16.x"
           registry-url: "https://registry.npmjs.org"
 
         # Setup Git

--- a/.github/workflows/pull_request_builds.yml
+++ b/.github/workflows/pull_request_builds.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: "12.x"
+          node-version: "16.x"
           registry-url: "https://registry.npmjs.org"
 
       # Lets us use one-liner JSON manipulations on package.jsons

--- a/.github/workflows/ship_tags.yml
+++ b/.github/workflows/ship_tags.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: "12.x"
+          node-version: "16.x"
           registry-url: "https://registry.npmjs.org"
 
       # Lets us use one-liner JSON manipulations on package.jsons


### PR DESCRIPTION
An old version of npm is causing an error in a downstream script. The current LTS ships with a version of npm that works.