### PR TITLE
Pull typescript from typescript.js

### DIFF
--- a/publish-monaco-editor.js
+++ b/publish-monaco-editor.js
@@ -63,6 +63,13 @@ function main() {
   execME("git remote add andrewbranch https://github.com/andrewbranch/monaco-editor.git")
   execME("git fetch andrewbranch")
   failableMergeBranch(execME, "andrewbranch/update-ts")
+
+  // Use typescript.js instead of typescriptServices.js
+  // https://github.com/microsoft/monaco-editor/pull/3344
+  execME("git remote add jakebailey https://github.com/jakebailey/monaco-editor.git")
+  execME("git fetch jakebailey")
+  failableMergeBranch(execME, "jakebailey/ignore-typescript-services")
+
   execME("git rev-parse HEAD")
 
   const user = envUser || exec("npm whoami").toString().trim();


### PR DESCRIPTION
Pulls in https://github.com/microsoft/monaco-editor/pull/3344 so that builds from here come from `typescript.js`, which is identical to `typescriptServices.js` besides the source map URL.

See: https://github.com/microsoft/TypeScript/issues/50758
