### PR TITLE
Pull in module transform support

### DIFF
--- a/publish-monaco-editor.js
+++ b/publish-monaco-editor.js
@@ -69,6 +69,7 @@ function main() {
   execME("git remote add jakebailey https://github.com/jakebailey/monaco-editor.git")
   execME("git fetch jakebailey")
   failableMergeBranch(execME, "jakebailey/ignore-typescript-services")
+  failableMergeBranch(execME, "jakebailey/support-module-transform")
 
   execME("git rev-parse HEAD")
 


### PR DESCRIPTION
See: https://github.com/jakebailey/monaco-editor/commit/7e1e4d4cec1349f228cbb7799fde70391a677481

The regexes that hack away require don't work on the new module transform, because the code is different.

It'd be better to instead run a transform over the TS source or something in monaco (and TS), rather than using regexes, but that's a bigger change. But, I don't know how long this change will continue to work for.