### PR TITLE
Silence 6.0 deprecations

### DIFF
--- a/publish-monaco-editor.js
+++ b/publish-monaco-editor.js
@@ -98,6 +98,11 @@ function main() {
   const typeScriptVersion = execME("json -f node_modules/typescript/package.json version").toString().trim();
   execME(`json -I -f package.json -e "this.version='${typeScriptVersion}'"`);
 
+  if (typeScriptVersion.startsWith("6.")) {
+    step("Silencing 6.0 deprecations");
+    execME(`json -I -f src/tsconfig.json -e "this.compilerOptions.ignoreDeprecations='6.0'"`);
+  }
+
   step("Creating release folder");
   execME(`npm run build-monaco-editor`);
 


### PR DESCRIPTION
```
> @typescript-deploys/monaco-editor@6.0.0-pr-55267-269 build
> ts-node ./build/build-languages

Launching compiler at src/tsconfig.json...
Error: src/tsconfig.json(6,23): error TS5107: Option 'moduleResolution=node10' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
/mnt/vss/_work/TypeScript-Make-Monaco-Builds/TypeScript-Make-Monaco-Builds/publish-monaco-editor.js:15
    throw error
    ^

```

Yay