### PR TITLE
Fix: use App token for cross-repo access, accept new bot user ID

### DIFF
--- a/.github/workflows/pull_request_builds.yml
+++ b/.github/workflows/pull_request_builds.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Publish PR Build
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           BOT_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
         run: |

--- a/pulls/comment-on-release.ts
+++ b/pulls/comment-on-release.ts
@@ -32,7 +32,7 @@ try {
   });
 
   // Get comments by the TS bot and sort them so the most recent is first
-  const messagesByTheBot = results.filter(issue => issue.user?.id === 23042052).reverse();
+  const messagesByTheBot = results.filter(issue => issue.user?.id === 23042052 || issue.user?.id === 290192711).reverse();
   const messageWithTGZ = messagesByTheBot.find(m => m.body?.includes("an installable tgz") && m.body?.includes("packed"));
 
   // If we find it and it's not sneakily been edited already

--- a/pulls/echo-release-version.ts
+++ b/pulls/echo-release-version.ts
@@ -25,7 +25,7 @@ try {
 
   // Get comments by the TS bot and sort them so the most recent is first
   const messagesByTheBot = results
-    .filter(issue => issue.user?.id === 23042052)
+    .filter(issue => issue.user?.id === 23042052 || issue.user?.id === 290192711)
     .reverse();
 
   const messageWithTGZ = messagesByTheBot.find(m => m.body?.includes("an installable tgz") && m.body?.includes("packed"))

--- a/pulls/echo-typescript-url.ts
+++ b/pulls/echo-typescript-url.ts
@@ -23,7 +23,7 @@ try {
 
   // Get comments by the TS bot and sort them so the most recent is first
   const messagesByTheBot = results
-    .filter(issue => issue.user?.id === 23042052)
+    .filter(issue => issue.user?.id === 23042052 || issue.user?.id === 290192711)
     .map(issue => issue.body)
     .filter((body): body is string => body != null)
     .reverse();


### PR DESCRIPTION
- Set GITHUB_TOKEN to the App token (instead of the built-in Actions token) so scripts can read comments from microsoft/TypeScript
- Accept both old (23042052) and new (290192711) bot user IDs when filtering comments
- Fixes PR build workflow failing with 403 on cross-repo API calls