### PR TITLE
Fix: add --tag to npm publish for prerelease versions

### DIFF
--- a/pulls/republish-typescript-tarball.ts
+++ b/pulls/republish-typescript-tarball.ts
@@ -57,7 +57,7 @@ const go = async () => {
   exec(`json -I -f typescript/package/package.json -e "this.scripts.prepare=''"`)
  
   step("Publishing PR build to npm");
-  exec(`npm publish --access=public --tag pr-build`, { cwd: "typescript/package" })
+  exec("npm publish --access=public --tag pr-build", { cwd: "typescript/package" })
 }
 
 go()

--- a/pulls/republish-typescript-tarball.ts
+++ b/pulls/republish-typescript-tarball.ts
@@ -57,7 +57,7 @@ const go = async () => {
   exec(`json -I -f typescript/package/package.json -e "this.scripts.prepare=''"`)
  
   step("Publishing PR build to npm");
-  exec("npm publish --access=public", { cwd: "typescript/package" })
+  exec(`npm publish --access=public --tag pr-build`, { cwd: "typescript/package" })
 }
 
 go()


### PR DESCRIPTION
npm 11 (shipped with Node 24) requires `--tag` when publishing prerelease versions. Without it, `npm publish` fails with:

```
npm error You must specify a tag using --tag when publishing a prerelease version.
```

This was broken by #65 (Node 22→24 upgrade).